### PR TITLE
Upgrade the Plugin Publishing Plugin dependency to version 1.1.0.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
-	id("com.gradle.plugin-publish") version "0.19.0"
+	id("com.gradle.plugin-publish") version "1.1.0"
 	id("com.github.ben-manes.versions") version "0.41.0"
-	`java-gradle-plugin`
 	`maven-publish`
 	`embedded-kotlin`
 	`kotlin-dsl`


### PR DESCRIPTION
The version of the Plugin Publishing Plugin used so far uses deprecated Gradle features, making it incompatible with Gradle 8.0.

The proposed solution is to upgrade that plugin to it latest version 1.1.0.