### PR TITLE
Upgrade to Apache FOP 2.9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ gradlePlugin {
 
 dependencies {
 	implementation("org.apache.avalon.framework:avalon-framework-impl:4.3.1")
-	implementation("org.apache.xmlgraphics:fop:2.6")
+	implementation("org.apache.xmlgraphics:fop:2.9")
 	implementation("net.sf.offo:fop-hyph:2.0")
 	implementation("xalan:xalan:2.7.2")
 }


### PR DESCRIPTION
FOP 2.9 is the latest version and includes a couple of new features. See https://xmlgraphics.apache.org/fop/2.9/releaseNotes_2.9.html